### PR TITLE
[FIX] load operations when present

### DIFF
--- a/src/routes/Router.re
+++ b/src/routes/Router.re
@@ -17,7 +17,7 @@ let make = () => {
       {switch (url.path) {
        | [_, "accounts", _] =>
          <Account items={state.account} goToDetail=onSearchById />
-       | [_, "operations", _] =>
+       | [_, "operations", _] when state.operation |> Array.length > 0 =>
          <Operation items={state.operation} goToDetail=onSearchById />
        | [_, "blocks", _] =>
          <Block


### PR DESCRIPTION
When entering an URL app was trying to display operations before they were loaded. The operations component wasn't able to handle an empty array of operations.