### PR TITLE
[FIX] Fix redirect url to arronax for `All received transactions`

### DIFF
--- a/src/routes/Account.re
+++ b/src/routes/Account.re
@@ -7,10 +7,8 @@ let make = (~items, ~goToDetail) => {
     Js.log2("level", level);
     ();
   };
-  let (id, _) =
-    React.useState(() => Utils.getValueFromDict(items, "account_id"));
-  let (displayName, _) =
-    React.useState(() => Utils.getDisplayName(configs[theme]));
+  let id = Utils.getValueFromDict(items, "account_id");
+  let displayName = Utils.getDisplayName(configs[theme]);
 
   let onOpenAccountSends = _ev =>
     Queries.getQueryForAccountSends(id)


### PR DESCRIPTION
Example [redirect](https://arronax.io/?e=Tezos%20Mainnet/operations&q=eyJmaWVsZHMiOlsidGltZXN0YW1wIiwiYmxvY2tfaGFzaCIsIm9wZXJhdGlvbl9ncm91cF9oYXNoIiwia2luZCIsInNvdXJjZSIsImRlc3RpbmF0aW9uIiwiYW1vdW50IiwiZmVlIiwic3RhdHVzIl0sInByZWRpY2F0ZXMiOlt7ImZpZWxkIjoiZGVzdGluYXRpb24iLCJvcGVyYXRpb24iOiJlcSIsInNldCI6WyJ0ejFXNVZrZEI1czdFTk1FU1ZCdHd5dDlreXZMcVBjVWN6UlQiXSwiaW52ZXJzZSI6ZmFsc2V9LHsiZmllbGQiOiJraW5kIiwib3BlcmF0aW9uIjoiZXEiLCJzZXQiOlsidHJhbnNhY3Rpb24iXSwiaW52ZXJzZSI6ZmFsc2V9XSwib3JkZXJCeSI6W10sImFnZ3JlZ2F0aW9uIjpbXSwibGltaXQiOjEwMDB9) for an account: `tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT`